### PR TITLE
Fallback to JSON file name if asset ID is missing; warn on auto zoom failure. Fixes #76

### DIFF
--- a/toolbox/GEE_Connector.pyt
+++ b/toolbox/GEE_Connector.pyt
@@ -19,7 +19,7 @@ import json
 import requests
 from google.cloud import storage
 import arcgee
-
+from pathlib import Path
 
 """ Toolbox """
 
@@ -544,6 +544,9 @@ class AddImg2MapbyID:
             centroid_coords, bounds_coords = arcgee.data.get_object_centroid(img, 1)
             arcgee.map.zoom_to_point(aprx, centroid_coords, bounds_coords)
         except:
+            arcpy.AddWarning(
+                "Automatic zoom to the image failed. Please zoom manually."
+            )
             pass
 
         # Save image object to serialized JSON file
@@ -710,6 +713,11 @@ class AddImg2MapbyObj:
         # Get image by label
         img = arcgee.data.load_ee_result(json_path)
         img_id = img.get("system:id").getInfo()
+        # The image object could lose image ID information after reducers are applied.
+        # Use the JSON file name as image ID if image ID is not found.
+        if not img_id:
+            img_id = Path(json_path).stem
+
         # Get the map ID and token
         map_id_dict = img.getMapId(vis_params)
 
@@ -731,6 +739,9 @@ class AddImg2MapbyObj:
             centroid_coords, bounds_coords = arcgee.data.get_object_centroid(img, 1)
             arcgee.map.zoom_to_point(aprx, centroid_coords, bounds_coords)
         except:
+            arcpy.AddWarning(
+                "Automatic zoom to the image failed. Please zoom manually."
+            )
             pass
         return
 
@@ -1034,6 +1045,9 @@ class AddImgCol2MapbyID:
             centroid_coords, bounds_coords = arcgee.data.get_object_centroid(img, 1)
             arcgee.map.zoom_to_point(aprx, centroid_coords, bounds_coords)
         except:
+            arcpy.AddWarning(
+                "Automatic zoom to the image failed. Please zoom manually."
+            )
             pass
 
         # Save filtered image collection to serialized JSON file
@@ -1229,7 +1243,12 @@ class AddImgCol2MapbyObj:
         collection = arcgee.data.load_ee_result(json_path)
         # Get image id for layer name
         asset_id = collection.get("system:id").getInfo()
-        img_id = asset_id + "/" + img_name
+        # Prepend asset id if it exists, otherwise use image name.
+        if asset_id:
+            img_id = f"{asset_id}/{img_name}"
+        else:
+            img_id = img_name
+
         # Get image by label
         img = ee.Image(img_id)
 
@@ -1290,6 +1309,9 @@ class AddImgCol2MapbyObj:
             centroid_coords, bounds_coords = arcgee.data.get_object_centroid(img, 1)
             arcgee.map.zoom_to_point(aprx, centroid_coords, bounds_coords)
         except:
+            arcpy.AddWarning(
+                "Automatic zoom to the image failed. Please zoom manually."
+            )
             pass
 
         return
@@ -1699,6 +1721,9 @@ class AddFeatCol2MapbyID:
                 centroid_coords, bounds_coords = arcgee.data.get_object_centroid(fc, 1)
                 arcgee.map.zoom_to_point(aprx, centroid_coords, bounds_coords)
             except:
+                arcpy.AddWarning(
+                    "Automatic zoom to the feature collection failed. Please zoom manually."
+                )
                 pass
 
             # Save object to serialized JSON file
@@ -1846,6 +1871,12 @@ class AddFeatCol2MapbyObj:
         # load collection object
         fc = arcgee.data.load_ee_result(json_path)
         asset_id = fc.get("system:id").getInfo()
+        # Get asset id for layer name
+        if asset_id:
+            feat_id = asset_id
+        else:
+            # Use the json file name as feature id if asset id is not found
+            feat_id = Path(json_path).stem
 
         # TODO: add more visualization parameters
         # point_shape= parameters[2].valueAsText
@@ -1899,13 +1930,16 @@ class AddFeatCol2MapbyObj:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
             aprxMap = aprx.listMaps("Map")[0]
             tsl = aprxMap.addDataFromPath(map_url)
-            tsl.name = asset_id
+            tsl.name = feat_id
 
             # Zoom to feature collection centroid if provided by dataset
             try:
                 centroid_coords, bounds_coords = arcgee.data.get_object_centroid(fc, 1)
                 arcgee.map.zoom_to_point(aprx, centroid_coords, bounds_coords)
             except:
+                arcpy.AddWarning(
+                    "Automatic zoom to the feature collection failed. Please zoom manually."
+                )
                 pass
 
         else:
@@ -5493,7 +5527,10 @@ class ApplyMapFunctionbyObj:
             raise ValueError(f"Unsupported data type: {data_type}")
 
         asset_id = ee_object.getInfo()["id"]
-        arcpy.AddMessage(f"Asset ID: {asset_id}")
+        if asset_id:
+            arcpy.AddMessage(f"Asset ID: {asset_id}")
+        else:
+            arcpy.AddWarning("The asset ID is missing.")
 
         # Apply the filters from the filter list to the Earth Engine object
         for func_str in function_list:
@@ -5979,7 +6016,6 @@ class ApplyReducerbyObj:
 
         # Save the serialized string as JSON to the specified output path
         if not out_json.endswith(".json"):
-
             out_json = out_json + ".json"
 
         # save to json

--- a/toolbox/GEE_Connector.pyt.xml
+++ b/toolbox/GEE_Connector.pyt.xml
@@ -5,8 +5,8 @@
     <CreaTime>15490700</CreaTime>
     <ArcGISFormat>1.0</ArcGISFormat>
     <SyncOnce>TRUE</SyncOnce>
-    <ModDate>20250619</ModDate>
-    <ModTime>112901</ModTime>
+    <ModDate>20250620</ModDate>
+    <ModTime>095952</ModTime>
   </Esri>
   <toolbox name="GEE_Connector" alias="GEE_Connector">
     <arcToolboxHelpPath>c:\program files\arcgis\pro\Resources\Help\gp</arcToolboxHelpPath>


### PR DESCRIPTION
- Fallback to JSON file name if asset ID is missing; warn on auto zoom failure. Fixes #76 
- Resolve comments from previous PR review