### PR TITLE
Fix disk space bug in image download; use object extent as ROI fallback. Fixes #63

### DIFF
--- a/toolbox/GEE_Connector.pyt
+++ b/toolbox/GEE_Connector.pyt
@@ -2161,6 +2161,15 @@ class DownloadImgbyID:
         image = ee.ImageCollection(ee.Image(img_id))
         # Filter image by selected bands
         image = image.select(bands_only)
+        # Get ROI from the object extent if not provided
+        if roi is None:
+            try:
+                roi = arcgee.data.get_roi_from_object(image)
+            except Exception as e:
+                arcpy.AddWarning(
+                    f"Error getting ROI from object: {e}. "
+                    "No ROI provided, downloading the entire image may cause memory issues!"
+                )
 
         # check if use projection
         use_projection = arcgee.data.whether_use_projection(image)
@@ -2384,6 +2393,14 @@ class DownloadImgbyObj:
         image = ee.ImageCollection(ee.Image(img_id))
         # Filter image by selected bands
         image = image.select(bands_only)
+        if roi is None:
+            try:
+                roi = arcgee.data.get_roi_from_object(image)
+            except Exception as e:
+                arcpy.AddWarning(
+                    f"Error getting ROI from object: {e}. "
+                    "No ROI provided, downloading the entire image may cause memory issues!"
+                )
 
         # check if use projection
         use_projection = arcgee.data.whether_use_projection(image)
@@ -2714,28 +2731,16 @@ class DownloadImgColbyID:
             image = image.select(bands_only)
             if roi is None:
                 try:
-                    arcpy.AddMessage("Try to get ROI from the object ...")
-                    # get extend of the object
-                    centroid_coords, bounds_coords = arcgee.data.get_object_centroid(
-                        image, 1
-                    )
-                    x_min, y_min, x_max, y_max = arcgee.data.convert_coords_to_bbox(
-                        bounds_coords
-                    )
-                    arcpy.AddMessage([x_min, y_min, x_max, y_max])
-                    roi_used = ee.Geometry.BBox(x_min, y_min, x_max, y_max)
-                except:
+                    roi = arcgee.data.get_roi_from_object(image)
+                except Exception as e:
                     arcpy.AddWarning(
-                        "No ROI provided, download entire image ... This may cause memory issues!"
+                        f"Error getting ROI from object: {e}. "
+                        "No ROI provided, downloading the entire image may cause memory issues!"
                     )
-                    roi_used = None
-
-            else:
-                roi_used = roi
 
             # download image as geotiff
             arcgee.data.image_to_geotiff(
-                image, bands_only, crs, scale_ds, roi_used, use_projection, out_tiff
+                image, bands_only, crs, scale_ds, roi, use_projection, out_tiff
             )
 
         # Add out tiff to map layer
@@ -3002,28 +3007,16 @@ class DownloadImgColbyObj:
 
             if roi is None:
                 try:
-                    arcpy.AddMessage("Try to get ROI from the object ...")
-                    # get extend of the object
-                    centroid_coords, bounds_coords = arcgee.data.get_object_centroid(
-                        image, 1
-                    )
-                    x_min, y_min, x_max, y_max = arcgee.data.convert_coords_to_bbox(
-                        bounds_coords
-                    )
-                    arcpy.AddMessage([x_min, y_min, x_max, y_max])
-                    roi_used = ee.Geometry.BBox(x_min, y_min, x_max, y_max)
-                except:
+                    roi = arcgee.data.get_roi_from_object(image)
+                except Exception as e:
                     arcpy.AddWarning(
-                        "No ROI provided, download entire image ... This may cause memory issues!"
+                        f"Error getting ROI from object: {e}. "
+                        "No ROI provided, downloading the entire image may cause memory issues!"
                     )
-                    roi_used = None
-
-            else:
-                roi_used = roi
 
             # download image as geotiff
             arcgee.data.image_to_geotiff(
-                image, bands_only, crs, scale_ds, roi_used, use_projection, out_tiff
+                image, bands_only, crs, scale_ds, roi, use_projection, out_tiff
             )
 
         # Add out tiff to map layer

--- a/toolbox/GEE_Connector.pyt.xml
+++ b/toolbox/GEE_Connector.pyt.xml
@@ -6,7 +6,7 @@
     <ArcGISFormat>1.0</ArcGISFormat>
     <SyncOnce>TRUE</SyncOnce>
     <ModDate>20250620</ModDate>
-    <ModTime>095952</ModTime>
+    <ModTime>125332</ModTime>
   </Esri>
   <toolbox name="GEE_Connector" alias="GEE_Connector">
     <arcToolboxHelpPath>c:\program files\arcgis\pro\Resources\Help\gp</arcToolboxHelpPath>


### PR DESCRIPTION
- Fix disk space bug in image download; use object extent as ROI fallback. Fixes #63 
- Add a function to get ROI from object extent
- Add warning when object extent is missing
- Update download image/image collection scripts 
- Add PermissionError when ArcGIS Pro does not allow running subprocesses
- Resolve comments from previous PR review