### PR TITLE
Prevent download of meaningless raster when ROI lacks valid data. Fixes #48

### DIFF
--- a/toolbox/GEE_Connector.pyt.xml
+++ b/toolbox/GEE_Connector.pyt.xml
@@ -5,8 +5,8 @@
     <CreaTime>15490700</CreaTime>
     <ArcGISFormat>1.0</ArcGISFormat>
     <SyncOnce>TRUE</SyncOnce>
-    <ModDate>20250625</ModDate>
-    <ModTime>103954</ModTime>
+    <ModDate>20250702</ModDate>
+    <ModTime>030542</ModTime>
   </Esri>
   <toolbox name="GEE_Connector" alias="GEE_Connector">
     <arcToolboxHelpPath>c:\program files\arcgis\pro\Resources\Help\gp</arcToolboxHelpPath>

--- a/toolbox/arcgee/data.py
+++ b/toolbox/arcgee/data.py
@@ -1498,3 +1498,19 @@ def check_start_date(parameter):
     if not val_list[0][0]:
         parameter.setErrorMessage("Start date is required when end date is provided.")
         return
+
+
+# Check if an image has valid pixels.
+def has_valid_pixels(image: "ee.Image", roi: "ee.Geometry", scale: int) -> bool:
+    """Check if an image has valid pixels.
+
+    Args:
+        image : Input image
+        roi : Region of interest
+
+    Returns:
+        bool: True if the image has valid pixels, False otherwise
+    """
+    sample = image.sample(region=roi, scale=scale, numPixels=30)
+
+    return sample.size().gt(0).getInfo()

--- a/toolbox/arcgee/map.py
+++ b/toolbox/arcgee/map.py
@@ -116,6 +116,7 @@ def get_map_view_extent(target_epsg=4326):
 
     # Extract the projection and the boundary coordinates (extent).
     spatial_ref = camera.getExtent().spatialReference
+    arcpy.AddMessage(f"The current map projection is EPSG:{spatial_ref.factoryCode}.")
     xmin = camera.getExtent().XMin
     ymin = camera.getExtent().YMin
     xmax = camera.getExtent().XMax
@@ -127,9 +128,8 @@ def get_map_view_extent(target_epsg=4326):
     # can not be converted to ESPG 4326 (latitude and longitude).
     # Need to clip the map extent coordinates to valid EPSG 3857 extent.
     if spatial_ref.PCSCode == 3857:
-        arcpy.AddMessage("The current projection is EPSG 3857.")
         xmin, ymin, xmax, ymax = clip_to_epsg3857_extent(xmin, ymin, xmax, ymax)
-        arcpy.AddMessage("The map extent has been clipped to valid EPSG 3857 extent.")
+        arcpy.AddMessage("The map extent has been clipped to valid EPSG:3857 extent.")
     # Check if projection code is the target EPSG code.
     # projected
     poly_prj = spatial_ref.PCSCode
@@ -139,9 +139,10 @@ def get_map_view_extent(target_epsg=4326):
     # Always using latitude and longtiude for ee.Geometry, ee will automatically transform.
     if str(poly_prj) not in "EPSG:" + str(target_epsg):
         # Convert the extent corners to target EPSG.
+        arcpy.AddMessage(f"Converting the extent corners to target EPSG:{target_epsg}.")
         xmin, ymin = project_to_new_sr(xmin, ymin, spatial_ref, target_epsg)
         xmax, ymax = project_to_new_sr(xmax, ymax, spatial_ref, target_epsg)
-
+    arcpy.AddMessage([xmin, ymin, xmax, ymax])
     return xmin, ymin, xmax, ymax
 
 


### PR DESCRIPTION
- Prevent download of meaningless raster when ROI lacks valid data. Fixes #48 
- Add image sampling function to check for valid pixels within the ROI before download
- Display a warning message and skip download if no valid pixels are found in the ROI
- Update the following scripts accordingly
  - Download Image by Asset ID 
  - Download Image by Serialized JSON Object
  - Download Image Collection by Asset ID 
  - Download Image Collection by Serialized JSON Object
  - Download Image Collection by Asset ID at Multiple Regions  