### PR TITLE
fix: enhance messaging to users during ROI processing (#160)

### DIFF
--- a/toolbox/GEE_Connector.pyt.xml
+++ b/toolbox/GEE_Connector.pyt.xml
@@ -5,8 +5,8 @@
     <CreaTime>15490700</CreaTime>
     <ArcGISFormat>1.0</ArcGISFormat>
     <SyncOnce>TRUE</SyncOnce>
-    <ModDate>20251119</ModDate>
-    <ModTime>222908</ModTime>
+    <ModDate>20251204</ModDate>
+    <ModTime>132343</ModTime>
   </Esri>
   <toolbox name="GEE_Connector" alias="GEE_Connector">
     <arcToolboxHelpPath>c:\program files\arcgis\pro\Resources\Help\gp</arcToolboxHelpPath>

--- a/toolbox/arcgee/data.py
+++ b/toolbox/arcgee/data.py
@@ -1267,6 +1267,7 @@ def get_polygon_coords(in_poly: str) -> list[list[list[float]]]:
         list: List of polygon coordinates in WGS 84 (list of rings, each ring is list of [x, y])
     """
     spatial_ref = arcpy.Describe(in_poly).spatialReference
+    arcpy.AddMessage(f"The polygon CRS is EPSG:{spatial_ref.factoryCode}.")
     poly_prj = spatial_ref.PCSCode
     if poly_prj == 0:
         poly_prj = spatial_ref.GCSCode
@@ -1274,6 +1275,7 @@ def get_polygon_coords(in_poly: str) -> list[list[list[float]]]:
     # Project to EPSG:4326 if needed
     target_poly = in_poly
     if str(poly_prj) not in "EPSG:4326":
+        arcpy.AddMessage(f"Converting the polygon to EPSG:4326.")
         out_sr = arcpy.SpatialReference(4326)
         arcpy.Project_management(in_poly, "poly_temp", out_sr)
         target_poly = "poly_temp"

--- a/toolbox/arcgee/map.py
+++ b/toolbox/arcgee/map.py
@@ -148,7 +148,7 @@ def get_map_view_extent(target_epsg: int = 4326) -> tuple[float, float, float, f
 
     # Extract the projection and the boundary coordinates (extent).
     spatial_ref = camera.getExtent().spatialReference
-    arcpy.AddMessage(f"The current map projection is EPSG:{spatial_ref.factoryCode}.")
+    arcpy.AddMessage(f"The current map CRS is EPSG:{spatial_ref.factoryCode}.")
     xmin = camera.getExtent().XMin
     ymin = camera.getExtent().YMin
     xmax = camera.getExtent().XMax


### PR DESCRIPTION
1. When a custom polygon is used as ROI, provide its CRS code and whether conversion to EPSG4326 is needed.  
2. Disable the “use current map view” option when a user-specified polygon is provided to avoid confusion. 
3. Update pop-up messages related to "projection", and change them to "CRS" if needed. 